### PR TITLE
Closes #2452: Clean-up fetched files during rollback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>${httpclient.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsImagesPatternCalculatingStep.java
+++ b/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsImagesPatternCalculatingStep.java
@@ -1,6 +1,6 @@
 package pl.edu.icm.pl.mxrdr.extension.workflow.step;
 
-import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionContext;
+import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionStepContext;
 import edu.harvard.iq.dataverse.workflow.step.Failure;
 import edu.harvard.iq.dataverse.workflow.step.FilesystemAccessingWorkflowStep;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepParams;
@@ -66,7 +66,7 @@ public class XdsImagesPatternCalculatingStep extends FilesystemAccessingWorkflow
     // -------------------- LOGIC --------------------
 
     @Override
-    protected WorkflowStepResult.Source runInternal(WorkflowExecutionContext context, Path workDir) throws IOException {
+    protected WorkflowStepResult.Source runInternal(WorkflowExecutionStepContext context, Path workDir) throws IOException {
         List<String> fileNames = readFileNamesIn(workDir);
         log.trace("Calculating XDS images name pattern for {} files", fileNames.size());
         String namePattern = calculatePattern(fileNames);
@@ -78,12 +78,12 @@ public class XdsImagesPatternCalculatingStep extends FilesystemAccessingWorkflow
     }
 
     @Override
-    public WorkflowStepResult resume(WorkflowExecutionContext context, Map<String, String> internalData, String externalData) {
+    public WorkflowStepResult resume(WorkflowExecutionStepContext context, Map<String, String> internalData, String externalData) {
         throw new UnsupportedOperationException("This step des not pause");
     }
 
     @Override
-    public void rollback(WorkflowExecutionContext context, Failure reason) {
+    public void rollback(WorkflowExecutionStepContext context, Failure reason) {
     }
 
     // -------------------- PRIVATE --------------------

--- a/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsInputAdjustingStep.java
+++ b/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsInputAdjustingStep.java
@@ -1,7 +1,7 @@
 package pl.edu.icm.pl.mxrdr.extension.workflow.step;
 
 import com.google.common.io.InputSupplier;
-import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionContext;
+import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionStepContext;
 import edu.harvard.iq.dataverse.workflow.step.Failure;
 import edu.harvard.iq.dataverse.workflow.step.FilesystemAccessingWorkflowStep;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepParams;
@@ -70,7 +70,7 @@ public class XdsInputAdjustingStep extends FilesystemAccessingWorkflowStep {
     // -------------------- LOGIC --------------------
 
     @Override
-    protected WorkflowStepResult.Source runInternal(WorkflowExecutionContext context, Path workDir) throws Exception {
+    protected WorkflowStepResult.Source runInternal(WorkflowExecutionStepContext context, Path workDir) throws Exception {
         log.trace("Adjusting {} with JOB={}", XDS_INPUT_FILE_NAME, jobsValue());
         addFailureArtifacts(XDS_INPUT_FILE_NAME);
         
@@ -90,12 +90,12 @@ public class XdsInputAdjustingStep extends FilesystemAccessingWorkflowStep {
     }
 
     @Override
-    public WorkflowStepResult resume(WorkflowExecutionContext context, Map<String, String> internalData, String externalData) {
+    public WorkflowStepResult resume(WorkflowExecutionStepContext context, Map<String, String> internalData, String externalData) {
         throw new UnsupportedOperationException("This step does not pause");
     }
 
     @Override
-    public void rollback(WorkflowExecutionContext workflowExecutionContext, Failure reason) { }
+    public void rollback(WorkflowExecutionStepContext workflowExecutionContext, Failure reason) { }
 
     // -------------------- PRIVATE --------------------
 

--- a/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsMissingInputFillingStep.java
+++ b/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsMissingInputFillingStep.java
@@ -4,7 +4,7 @@ import com.google.common.io.InputSupplier;
 import edu.harvard.iq.dataverse.dataset.datasetversion.DatasetVersionServiceBean;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
-import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionContext;
+import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionStepContext;
 import edu.harvard.iq.dataverse.workflow.step.Failure;
 import edu.harvard.iq.dataverse.workflow.step.FilesystemAccessingWorkflowStep;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepParams;
@@ -75,7 +75,7 @@ public class XdsMissingInputFillingStep extends FilesystemAccessingWorkflowStep 
     }
 
     @Override
-    protected WorkflowStepResult.Source runInternal(WorkflowExecutionContext context, Path workDir) throws Exception {
+    protected WorkflowStepResult.Source runInternal(WorkflowExecutionStepContext context, Path workDir) throws Exception {
         addFailureArtifacts(XDS_INPUT_FILE_NAME);
         List<XdsInputLineProcessor> processors = prepareProcessors(context);
         log.trace("Potentially adjusting values for {} XDS input parameters", processors.size());
@@ -95,16 +95,16 @@ public class XdsMissingInputFillingStep extends FilesystemAccessingWorkflowStep 
     }
 
     @Override
-    public WorkflowStepResult resume(WorkflowExecutionContext context, Map<String, String> internalData, String externalData) {
+    public WorkflowStepResult resume(WorkflowExecutionStepContext context, Map<String, String> internalData, String externalData) {
         throw new UnsupportedOperationException("This step does not pause");
     }
 
     @Override
-    public void rollback(WorkflowExecutionContext workflowExecutionContext, Failure failure) { }
+    public void rollback(WorkflowExecutionStepContext workflowExecutionContext, Failure failure) { }
 
     // -------------------- PRIVATE --------------------
 
-    private List<XdsInputLineProcessor> prepareProcessors(WorkflowExecutionContext context) {
+    private List<XdsInputLineProcessor> prepareProcessors(WorkflowExecutionStepContext context) {
         return versionsService
                 .withDatasetVersion(context,this::prepareProcessors)
                 .orElseGet(Collections::emptyList);

--- a/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsOutputImportingStep.java
+++ b/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsOutputImportingStep.java
@@ -7,7 +7,7 @@ import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldTypeRepository;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
-import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionContext;
+import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionStepContext;
 import edu.harvard.iq.dataverse.workflow.step.Failure;
 import edu.harvard.iq.dataverse.workflow.step.FilesystemAccessingWorkflowStep;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepParams;
@@ -57,7 +57,7 @@ public class XdsOutputImportingStep extends FilesystemAccessingWorkflowStep {
     // -------------------- LOGIC --------------------
 
     @Override
-    protected WorkflowStepResult.Source runInternal(WorkflowExecutionContext context, Path workDir) {
+    protected WorkflowStepResult.Source runInternal(WorkflowExecutionStepContext context, Path workDir) {
         addFailureArtifacts(XDS_INPUT_FILE_NAME, XDS_OUTPUT_FILE_NAME);
 
         versionsService.withDatasetVersion(context,
@@ -70,12 +70,12 @@ public class XdsOutputImportingStep extends FilesystemAccessingWorkflowStep {
     }
 
     @Override
-    public WorkflowStepResult resume(WorkflowExecutionContext context, Map<String, String> internalData, String externalData) {
+    public WorkflowStepResult resume(WorkflowExecutionStepContext context, Map<String, String> internalData, String externalData) {
         throw new UnsupportedOperationException("This step does not pause");
     }
 
     @Override
-    public void rollback(WorkflowExecutionContext context, Failure failure) {
+    public void rollback(WorkflowExecutionStepContext context, Failure failure) {
         versionsService.withDatasetVersion(context,
                 datasetVersion -> datasetVersion.getDatasetFields()
                         .removeIf(XdsOutputImportingStep::isXdsDatasetField)

--- a/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsValidateMetadataStep.java
+++ b/src/main/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsValidateMetadataStep.java
@@ -2,7 +2,7 @@ package pl.edu.icm.pl.mxrdr.extension.workflow.step;
 
 import edu.harvard.iq.dataverse.dataset.datasetversion.DatasetVersionServiceBean;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
-import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionContext;
+import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionStepContext;
 import edu.harvard.iq.dataverse.workflow.step.Failure;
 import edu.harvard.iq.dataverse.workflow.step.Success;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStep;
@@ -26,7 +26,7 @@ public class XdsValidateMetadataStep implements WorkflowStep {
     // -------------------- LOGIC --------------------
 
     @Override
-    public WorkflowStepResult run(WorkflowExecutionContext context) {
+    public WorkflowStepResult run(WorkflowExecutionStepContext context) {
         long dataCollectionFieldsCount = versionsService
                 .withDatasetVersion(context, this::countDataCollectionFields)
                 .orElse(0L);
@@ -42,12 +42,12 @@ public class XdsValidateMetadataStep implements WorkflowStep {
     }
 
     @Override
-    public WorkflowStepResult resume(WorkflowExecutionContext context, Map<String, String> internalData, String externalData) {
+    public WorkflowStepResult resume(WorkflowExecutionStepContext context, Map<String, String> internalData, String externalData) {
         throw new UnsupportedOperationException("This step does not pause");
     }
 
     @Override
-    public void rollback(WorkflowExecutionContext context, Failure failure) { }
+    public void rollback(WorkflowExecutionStepContext context, Failure failure) { }
 
     // -------------------- PRIVATE --------------------
 

--- a/src/test/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsMissingInputFillingStepTest.java
+++ b/src/test/java/pl/edu/icm/pl/mxrdr/extension/workflow/step/XdsMissingInputFillingStepTest.java
@@ -1,8 +1,9 @@
 package pl.edu.icm.pl.mxrdr.extension.workflow.step;
 
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
-import edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother;
+import edu.harvard.iq.dataverse.persistence.workflow.Workflow;
 import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionContext;
+import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionStepContext;
 import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionTestBase;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepParams;
 import org.junit.jupiter.api.AfterEach;
@@ -19,7 +20,10 @@ import java.util.List;
 
 import static edu.harvard.iq.dataverse.persistence.dataset.DatasetMother.givenDataset;
 import static edu.harvard.iq.dataverse.persistence.dataset.DatasetMother.givenDatasetFiled;
+import static edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother.givenWorkflow;
+import static edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother.givenWorkflowStep;
 import static edu.harvard.iq.dataverse.workflow.execution.WorkflowContextMother.givenWorkflowExecutionContext;
+import static edu.harvard.iq.dataverse.workflow.execution.WorkflowContextMother.nextStepContextToExecute;
 import static org.assertj.core.api.Assertions.assertThat;
 import static pl.edu.icm.pl.mxrdr.extension.xds.input.XdsInputFileProcessor.XDS_INPUT_FILE_NAME;
 
@@ -28,8 +32,10 @@ class XdsMissingInputFillingStepTest extends WorkflowExecutionTestBase {
     Path workDir;
 
     Dataset dataset = givenDataset(1L);
-    WorkflowExecutionContext context = givenWorkflowExecutionContext(
-            dataset.getId(), WorkflowMother.givenWorkflow(1L));
+    Workflow workflow = givenWorkflow(1L, givenWorkflowStep(XdsMissingInputFillingStep.STEP_ID));
+    WorkflowExecutionContext context = givenWorkflowExecutionContext(dataset.getId(), workflow);
+    WorkflowExecutionStepContext stepContext;
+
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -40,6 +46,9 @@ class XdsMissingInputFillingStepTest extends WorkflowExecutionTestBase {
 
         datasets.save(dataset);
         datasetVersions.save(dataset.getLatestVersion());
+
+        context.getExecution().start("test", "127.0.1.1", clock);
+        stepContext = nextStepContextToExecute(context);
     }
 
     @AfterEach
@@ -62,7 +71,7 @@ class XdsMissingInputFillingStepTest extends WorkflowExecutionTestBase {
         XdsMissingInputFillingStep step = new XdsMissingInputFillingStep(new WorkflowStepParams(), versionsService);
 
         // when
-        step.runInternal(context, workDir);
+        step.runInternal(stepContext, workDir);
 
         // then
         List<String> lines = Files.readAllLines(workDir.resolve(XDS_INPUT_FILE_NAME));
@@ -84,7 +93,7 @@ class XdsMissingInputFillingStepTest extends WorkflowExecutionTestBase {
         XdsMissingInputFillingStep step = new XdsMissingInputFillingStep(new WorkflowStepParams(), versionsService);
 
         // when
-        step.runInternal(context, workDir);
+        step.runInternal(stepContext, workDir);
 
         // then
         List<String> lines = Files.readAllLines(workDir.resolve(XDS_INPUT_FILE_NAME));
@@ -108,7 +117,7 @@ class XdsMissingInputFillingStepTest extends WorkflowExecutionTestBase {
         XdsMissingInputFillingStep step = new XdsMissingInputFillingStep(new WorkflowStepParams(), versionsService);
 
         // when
-        step.runInternal(context, workDir);
+        step.runInternal(stepContext, workDir);
 
         // then
         List<String> lines = Files.readAllLines(workDir.resolve(XDS_INPUT_FILE_NAME));
@@ -131,7 +140,7 @@ class XdsMissingInputFillingStepTest extends WorkflowExecutionTestBase {
         XdsMissingInputFillingStep step = new XdsMissingInputFillingStep(stepParams, versionsService);
 
         // when
-        step.runInternal(context, workDir);
+        step.runInternal(stepContext, workDir);
 
         // then
         List<String> lines = Files.readAllLines(workDir.resolve(XDS_INPUT_FILE_NAME));


### PR DESCRIPTION
The working directory is not cleaned up during workflow rollback, as it contains error log files which are accessible through UI.

The fetched files however are not necessary anymore, so we're cleaning those up in this PR.

To note: After successful workflow execution some empty directories are left behind on the server. We might want to clean those up as well.

Issue: CeON/dataverse#2452