### PR TITLE
Closes #124: Setup the XDS workflow in the dev environment

### DIFF
--- a/conf/glassfish/dataverse.properties
+++ b/conf/glassfish/dataverse.properties
@@ -1,0 +1,41 @@
+SolrHostColonPort=solr:8983
+
+SystemEmail=dataverseAdmin@mailinator.com
+BlockedApiPolicy=localhost-only
+FilePIDsEnabled=false
+# 5GB
+#MaxFileUploadSizeInBytes=5368709120
+# 10GB
+MaxFileUploadSizeInBytes=
+SingleUploadBatchMaxSize=32212254720
+ZipUploadFilesLimit=0
+Languages=[{"locale":"en", "title":"English"}]
+DoiProvider=FAKE
+DoiBaseUrlString=https://mds.test.datacite.org
+DoiUsername=dataciteuser
+DoiPassword=datacitepassword
+Authority=10.5072
+Shoulder=FK2/
+TimerServer=false
+SiteUrl=http://localhost:8080
+ProvCollectionEnabled=false
+GuidesBaseUrl=http://guides.dataverse.org
+FilesIntegrityCheckTimerExpression=0 0 1 * *
+ReadonlyMode=false
+ExcludeEmailFromExport=true
+
+SiteName=MX-RDR
+SiteFullName=Macromolecular Xtallography<br>Raw Data Repository
+CustomThemeCssFilename=theme_mxrdr.css
+MailOverseerAddress=drodb-test@icm.edu.pl
+
+GzipMaxInputFileSizeInBytes=200000000
+GzipMaxOutputFileSizeInBytes=1000000000
+
+FooterCustomizationFile=/opt/glassfish4/glassfish/domains/domain1/docroot/footer-logos-mxrdr.html
+NavbarAboutUrl=[{"url":"https://info.mxrdr.icm.edu.pl", "title.en":"About repository"}]
+
+GenerateXdsInpFullPath=generate_XDS.INP
+
+AntivirusScannerEnabled=true
+AntivirusScannerSocketAddress=localhost

--- a/conf/xds/macromolecularcrystallography.tsv
+++ b/conf/xds/macromolecularcrystallography.tsv
@@ -1,0 +1,159 @@
+#metadataBlock	name	dataverseAlias	displayName	blockURI
+	macromolecularcrystallography		Macromolecular Crystallography Metadata	
+#datasetField	name	title	description	watermark	fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	inputRendererType	inputRendererOptions	metadatablock_id	termURI	validation	metadata
+	sampleName	Sample Name			text	0		TRUE	FALSE	FALSE	FALSE	TRUE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	pdbId	PDB ID	Protein Data Bank identifier.		text	1		TRUE	FALSE	FALSE	FALSE	TRUE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	beamlineInstitution	Beamline Institution			text	2		TRUE	FALSE	FALSE	FALSE	TRUE	TRUE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	beamline	Beamline			text	3		TRUE	FALSE	FALSE	FALSE	TRUE	TRUE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	detectorType	Detector Type			text	4		TRUE	FALSE	FALSE	FALSE	TRUE	TRUE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	dataCollection	Data Collection			none	5	#NEWLINE	FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	dataCollectionWavelength	Wavelength [Å]		Enter a floating-point number...	float	6	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	TRUE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionDetectorDistance	Crystal-Detector Distance [mm]		Enter a floating-point number...	float	7	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	TRUE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionOscillationStepSize	Oscillation-Step Size [°]		Enter a floating-point number...	float	8	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	TRUE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionNumberOfFrames	Number of Frames	Number of collected images.	Enter an integer...	int	9	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	TRUE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	dataCollectionOrgX	Position of the Beam in the X Axis [px]		Enter a floating-point number...	float	10	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	TRUE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionOrgY	Position of the Beam in the Y Axis [px]		Enter a floating-point number...	float	11	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	TRUE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionTemperature	Temperature [K]		Enter a floating-point number...	float	12	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionStartingAngle	Starting Angle [°]		Enter a floating-point number...	float	13	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionDetectorThickness	Detector Thickness [mm]		Enter a floating-point number...	float	14	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	dataCollectionDetectorOverload	Detector Overload		Enter an integer...	int	15	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	dataCollection	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	spaceGroup	Space Group			text	16		TRUE	TRUE	FALSE	TRUE	TRUE	FALSE		VOCABULARY_SELECT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	unitCellParameters	Unit Cell Parameters			none	17	#NEWLINE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	unitCellParameterA	a [Å]		Enter a floating-point number...	float	18	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	unitCellParameters	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	unitCellParameterB	b [Å]		Enter a floating-point number...	float	19	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	unitCellParameters	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	unitCellParameterC	c [Å]		Enter a floating-point number...	float	20	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	unitCellParameters	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	unitCellParameterAlpha	α [°]		Enter a floating-point number...	float	21	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	unitCellParameters	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	unitCellParameterBeta	β [°]		Enter a floating-point number...	float	22	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	unitCellParameters	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	unitCellParameterGamma	γ [°]		Enter a floating-point number...	float	23	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	unitCellParameters	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overall	Overall			none	24	#NEWLINE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	overallCompleteness	Completeness		Enter a floating-point number...	float	25	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallISigma	Mean I/Sigma(I)		Enter a floating-point number...	float	26	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallCc	CC_1/2		Enter a floating-point number...	float	27	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallRMerge	R_merge		Enter a floating-point number...	float	28	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallRMeas	R_meas		Enter a floating-point number...	float	29	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallDataResolutionRangeLow	Resolution Low		Enter a floating-point number...	float	30	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallDataResolutionRangeHigh	Resolution High		Enter a floating-point number...	float	31	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallNumberOfObservedReflections	Number of Observed Reflections		Enter an integer...	int	32	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	overallNumberOfUniqueReflections	Number of Unique Reflections		Enter an integer...	int	33	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	overallNumberOfPossibleReflections	Number of Possible Reflections		Enter an integer...	int	34	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	overallAnomalousCorrelation	Anomalous Correlation		Enter a floating-point number...	float	35	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	overallAnomalousSignal	Anomalous Signal		Enter a floating-point number...	float	36	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	overall	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrs	Highest Resolution Shell			none	37	#NEWLINE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	hrsCompleteness	Completeness		Enter a floating-point number...	float	38	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsISigma	Mean I/Sigma(I)		Enter a floating-point number...	float	39	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsCc	CC_1/2		Enter a floating-point number...	float	40	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsRMerge	R_merge		Enter a floating-point number...	float	41	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsRMeas	R_meas		Enter a floating-point number...	float	42	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsDataResolutionRangeLow	Resolution Low		Enter a floating-point number...	float	43	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsDataResolutionRangeHigh	Resolution High		Enter a floating-point number...	float	44	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsNumberOfObservedReflections	Number of Observed Reflections		Enter an integer...	int	45	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	hrsNumberOfUniqueReflections	Number of Unique Reflections		Enter an integer...	int	46	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	hrsNumberOfPossibleReflections	Number of Possible Reflections		Enter an integer...	int	47	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	hrsAnomalousCorrelation	Anomalous Correlation		Enter a floating-point number...	float	48	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	hrsAnomalousSignal	Anomalous Signal		Enter a floating-point number...	float	49	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	hrs	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	monochromator	Monochromator Type			text	50		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	processingSoftware	Processing Software	Software used to process diffraction images.		text	51		TRUE	TRUE	TRUE	FALSE	TRUE	FALSE		VOCABULARY_SELECT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	refinementFactors	Refinement Factors			none	52	#NEWLINE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	refinementFactorRWork	R-work		Enter a floating-point number...	float	53	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	refinementFactors	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	refinementFactorRFree	R-free		Enter a floating-point number...	float	54	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	refinementFactors	TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	macromoleculeType	Macromolecule Type			text	55		TRUE	TRUE	TRUE	TRUE	TRUE	TRUE		VOCABULARY_SELECT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	molecularWeight	Molecular Weight [Da]		Enter a floating-point number...	float	56		TRUE	FALSE	FALSE	FALSE	TRUE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_number"}]	{}
+	entity	Entity	The distinct (chemically unique) protein, DNA or RNA molecules with defined sequence present in PDB entry.		none	57	#NEWLINE	FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	entityId	ID	Enter the numeric identifier of the entity, e.g. 1.		text	58	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	entity	TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	entitySequence	Sequence	Please provide a sequence for each entity separately.		textbox	59	#NAME: #VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	entity	TEXTBOX	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	entityCount	Entity Count		Enter an integer...	int	60		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	residueCount	Residue Count		Enter an integer...	int	61		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	atomSiteCount	Atom Site Count		Enter an integer...	int	62		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_int"}]	{}
+	pdbTitle	PDB Structure Title			text	63		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	pdbDoi	PDB DOI			text	64		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	pdbStructureAuthor	PDB Structure Author		FamilyName, GivenNameInitial.	text	65		TRUE	FALSE	TRUE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	pdbDepositDate	PDB Deposit Date	PDB Deposit Date in YYYY-MM-DD format.	YYYY-MM-DD	date	66		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_date","parameters":{"context":["DATASET"]}},{"name":"date_range","parameters":{"context":["SEARCH"]}}]	{}
+	pdbReleaseDate	PDB Release Date	PDB Release Date in YYYY-MM-DD format.	YYYY-MM-DD	date	67		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_date","parameters":{"context":["DATASET"]}},{"name":"date_range","parameters":{"context":["SEARCH"]}}]	{}
+	pdbRevisionDate	PDB Revision Date	PDB Revision Date in YYYY-MM-DD format.	YYYY-MM-DD	date	68		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_date","parameters":{"context":["DATASET"]}},{"name":"date_range","parameters":{"context":["SEARCH"]}}]	{}
+	citationTitle	PDB Primary Citation Title			text	69		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	citationPubmedId	PDB Primary Citation PubMed ID			text	70		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	citationAuthor	PDB Primary Citation Author		FamilyName, GivenNameInitial.	text	71		TRUE	FALSE	TRUE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	citationJournal	PDB Primary Citation Journal Name			text	72		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_input"}]	{}
+	citationYear	PDB Primary Citation Publication Year	PDB Primary Citation Publication Year in YYYY format.	YYYY	date	73		TRUE	FALSE	FALSE	FALSE	FALSE	FALSE		TEXT	{}	macromolecularcrystallography		[{"name":"standard_date","parameters":{"context":["DATASET"]}},{"name":"date_range","parameters":{"context":["SEARCH"]}}]	{}
+#controlledVocabulary	DatasetField	Value	identifier	displayOrder
+	spaceGroup	1. P1		0
+	spaceGroup	3. P2		1
+	spaceGroup	4. P2(1)		2
+	spaceGroup	5. C2		3
+	spaceGroup	16. P222		4
+	spaceGroup	17. P222(1)		5
+	spaceGroup	18. P2(1)2(1)2		6
+	spaceGroup	19. P2(1)2(1)2(1)		7
+	spaceGroup	20. C222(1)		8
+	spaceGroup	21. C222		9
+	spaceGroup	22. F222		10
+	spaceGroup	23. I222		11
+	spaceGroup	24. I2(1)2(1)2(1)		12
+	spaceGroup	75. P4		13
+	spaceGroup	76. P4(1)		14
+	spaceGroup	77. P4(2)		15
+	spaceGroup	78. P4(3)		16
+	spaceGroup	79. I4		17
+	spaceGroup	80. I4(1)		18
+	spaceGroup	89. P422		19
+	spaceGroup	90. P42(1)2		20
+	spaceGroup	91. P4(1)22		21
+	spaceGroup	92. P4(1)2(1)2		22
+	spaceGroup	93. P4(2)22		23
+	spaceGroup	94. P4(2)2(1)2		24
+	spaceGroup	95. P4(3)22		25
+	spaceGroup	96. P4(3)2(1)2		26
+	spaceGroup	97. I422		27
+	spaceGroup	98. I4(1)22		28
+	spaceGroup	143. P3		29
+	spaceGroup	144. P3(1)		30
+	spaceGroup	145. P3(2)		31
+	spaceGroup	146. R3		32
+	spaceGroup	149. P312		33
+	spaceGroup	150. P321		34
+	spaceGroup	151. P3(1)12		35
+	spaceGroup	152. P3(1)21		36
+	spaceGroup	153. P3(2)12		37
+	spaceGroup	154. P3(2)21		38
+	spaceGroup	155. R32		39
+	spaceGroup	168. P6		40
+	spaceGroup	169. P6(1)		41
+	spaceGroup	170. P6(5)		42
+	spaceGroup	171. P6(2)		43
+	spaceGroup	172. P6(4)		44
+	spaceGroup	173. P6(3)		45
+	spaceGroup	177. P622		46
+	spaceGroup	178. P6(1)22		47
+	spaceGroup	179. P6(5)22		48
+	spaceGroup	180. P6(2)22		49
+	spaceGroup	181. P6(4)22		50
+	spaceGroup	182. P6(3)22		51
+	spaceGroup	195. P23		52
+	spaceGroup	196. F23		53
+	spaceGroup	197. I23		54
+	spaceGroup	198. P2(1)3		55
+	spaceGroup	199. I2(1)3		56
+	spaceGroup	207. P432		57
+	spaceGroup	208. P4(2)32		58
+	spaceGroup	209. F432		59
+	spaceGroup	210. F4(1)32		60
+	spaceGroup	211. I432		61
+	spaceGroup	212. P4(3)32		62
+	spaceGroup	213. P4(1)32		63
+	spaceGroup	214. I4(1)32		64
+	spaceGroup	Other		65
+	processingSoftware	XDS		0
+	processingSoftware	Autoproc		1
+	processingSoftware	d*TREK		2
+	processingSoftware	Denzo		3
+	processingSoftware	Dials		4
+	processingSoftware	HKL2000/HKL3000		5
+	processingSoftware	MOSFLM/iMOSFLM		6
+	processingSoftware	xdsapp		7
+	processingSoftware	Xia2		8
+	processingSoftware	Other		9
+	macromoleculeType	Protein		0
+	macromoleculeType	RNA		1
+	macromoleculeType	DNA		2
+	macromoleculeType	RNA/DNA Hybrid		3
+	macromoleculeType	Other		4

--- a/conf/xds/workflow.json
+++ b/conf/xds/workflow.json
@@ -1,0 +1,136 @@
+{
+   "name":"XDS analysis",
+   "id":2,
+   "steps":[
+      {
+         "stepType":"xds-validate-metadata",
+         "provider":"mxrdr",
+         "parameters":{
+            
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"xds-fetch-images",
+         "provider":"mxrdr",
+         "parameters":{
+            "baseWorkDir":"/srv/glassfish/workflow"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"xds-calculate-images-pattern",
+         "provider":"mxrdr",
+         "parameters":{
+            
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"system-process",
+         "provider":"internal",
+         "parameters":{
+            "command":"generate_XDS.INP"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"xds-fill-missing-input",
+         "provider":"mxrdr",
+         "parameters":{
+            "xds_additional_params":"MAXIMUM_NUMBER_OF_PROCESSORS|2;MAXIMUM_NUMBER_OF_JOBS|1"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"xds-adjust-input",
+         "provider":"mxrdr",
+         "parameters":{
+            "jobs":"XYCORR;INIT;COLSPOT;IDXREF"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"system-process",
+         "provider":"internal",
+         "parameters":{
+            "command":"xds_par"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"xds-adjust-input",
+         "provider":"mxrdr",
+         "parameters":{
+            "jobs":"DEFPIX;INTEGRATE;CORRECT"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"system-process",
+         "provider":"internal",
+         "parameters":{
+            "command":"xds_par"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"xds-adjust-input",
+         "provider":"mxrdr",
+         "parameters":{
+            "adjustResolution":"true"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"system-process",
+         "provider":"internal",
+         "parameters":{
+            "command":"xds_par"
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"xds-output-import",
+         "provider":"mxrdr",
+         "parameters":{
+            
+         },
+         "requiredSettings":{
+            
+         }
+      },
+      {
+         "stepType":"clear-working-directory",
+         "provider":"internal",
+         "parameters":{
+            
+         },
+         "requiredSettings":{
+            
+         }
+      }
+   ]
+}

--- a/conf/xds/xds-setup.sh
+++ b/conf/xds/xds-setup.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+INSTALL_DIR="/opt/xds"
+BACKUP_DIR="/opt/xds_backup"
+XDS_TAR_DOWNLOAD_URL=https://xds.mr.mpg.de/XDS-INTEL64_Linux_x86_64.tar.gz
+XDS_TAR=$(basename ${XDS_TAR_DOWNLOAD_URL})
+GENERATE_XDS_INP_DOWNLOAD_URL=https://wiki.uni-konstanz.de/pub/linux_bin/generate_XDS.INP
+GENERATE_XDS_INP=$(basename $GENERATE_XDS_INP_DOWNLOAD_URL)
+
+DATAVERSE_API_HTTP="http://localhost:8080/api"
+WORKFLOW_JSON_FILE="workflow.json"
+METADATA_FILE="macromolecularcrystallography.tsv"
+
+(
+
+  usage() {
+    echo "Usage: $(basename $0) [command]"
+    echo "Commands: "
+    echo " install_all                Fresh installation of all components: XDS binaries, XDS workflow and metadata import."
+    echo " install_xds_bin            Install the latest XDS binaries"
+    echo " install_xds_workflow       Install xds analysis workflow"
+    echo " import_metadata            Import macro molecular crystallography metadata"
+    echo " show                       Display configuration"
+    echo " -h|help"
+    exit
+  }
+
+  install_all() {
+    install_xds_bin
+    install_xds_workflow
+    import_metadata
+  }
+
+  install_xds_bin() {
+    (
+      echo "Installing XDS binaries"
+      if [ -d ${INSTALL_DIR} ]; then
+        echo "Installation directory ${INSTALL_DIR} exists. Backing it up to $BACKUP_DIR"
+        if [ -d ${BACKUP_DIR} ]; then
+          echo "Cleaning existing backup directory ${BACKUP_DIR}"
+          rm -r ${BACKUP_DIR}
+        fi
+        mv $INSTALL_DIR $BACKUP_DIR
+      fi
+
+      mkdir -p ${INSTALL_DIR}
+      cd ${INSTALL_DIR}
+
+      wget --no-check-certificate ${XDS_TAR_DOWNLOAD_URL} && echo "Downloaded newest XDS binaries"
+      tar -xzf "${XDS_TAR}" --strip-components=1
+      rm -f "${XDS_TAR}"
+      wget --no-check-certificate ${GENERATE_XDS_INP_DOWNLOAD_URL} && echo "Downloaded generate_XDS.INP"
+      chmod a+x "${GENERATE_XDS_INP}"
+
+      if ! [[ "$PATH" =~ "$INSTALL_DIR:" ]]
+      then
+          {
+            echo ""
+            echo "export PATH=\"$INSTALL_DIR:\$PATH\""
+            echo ""
+          } >> ~/.bashrc
+      fi
+    )
+
+    echo "Done."
+  }
+
+  install_xds_workflow() {
+    echo "Importing workflow"
+    WORKFLOW_ID=$(curl -X POST ${DATAVERSE_API_HTTP}/admin/workflows -H 'Content-Type: application/json' -d @${SCRIPT_DIR}/${WORKFLOW_JSON_FILE} | sed -e 's/.*"id":\([0-9]*\),.*/\1/')
+    if ! [[ ${WORKFLOW_ID} =~ ^[0-9]+$ ]] ; then
+       echo "Error installing workflow. Response: ${WORKFLOW_ID}";
+       exit 1
+    fi
+
+    echo "Workflow imported with id:${WORKFLOW_ID}. Setting it now as default workflow for PostPublishDataset."
+    curl -X PUT http://localhost:8080/api/admin/workflows/default/PostPublishDataset -d "${WORKFLOW_ID}"
+
+    echo "Done."
+  }
+
+  import_metadata() {
+    echo "Loading Macro Molecular Crystallography metadata"
+    curl -X POST ${DATAVERSE_API_HTTP}/admin/datasetfield/load -H "Content-type: text/tab-separated-values" --upload-file ${SCRIPT_DIR}/${METADATA_FILE}
+
+    echo "Done."
+  }
+
+  show() {
+    echo "INSTALL_DIR: ${INSTALL_DIR}"
+    echo "BACKUP_DIR: ${BACKUP_DIR}"
+    echo "XDS_TAR_DOWNLOAD_URL: ${XDS_TAR_DOWNLOAD_URL}"
+    echo "XDS_TAR: ${XDS_TAR}"
+    echo "GENERATE_XDS_INP_DOWNLOAD_URL: ${GENERATE_XDS_INP_DOWNLOAD_URL}"
+    echo "GENERATE_XDS_INP: ${GENERATE_XDS_INP}"
+    echo "WORKFLOW_JSON_FILE: ${WORKFLOW_JSON_FILE}"
+    echo "METADATA_FILE: ${METADATA_FILE}"
+    echo "DATAVERSE_HTTP: ${DATAVERSE_HTTP}"
+  }
+
+  if [ $# -eq 0 ]; then
+    usage
+    exit
+  fi
+
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      install_all)
+        shift
+        install_all
+        exit
+        ;;
+      install_xds_bin)
+        shift
+        install_xds_bin
+        exit
+        ;;
+      install_xds_workflow)
+        shift
+        install_xds_workflow
+        exit
+        ;;
+      import_metadata)
+        shift
+        import_metadata
+        exit
+        ;;
+      show)
+        shift
+        show
+        exit
+        ;;
+      -h|--help)
+        usage
+        exit
+        ;;
+      *)
+        usage
+        exit
+        ;;
+    esac
+  done
+)

--- a/dev
+++ b/dev
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+export EXTENSION_SOURCE_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+export DATAVERSE_SOURCE_DIR="${DATAVERSE_SOURCE_DIR:-$( cd -- "$(dirname "$EXTENSION_SOURCE_DIR")/dataverse" >/dev/null 2>&1 ; pwd -P )}"
+export EXTENSION_DIST_DIR="${EXTENSION_SOURCE_DIR}/target"
+
+extension_post_install() {
+  echo "* Copying XDS installation files"
+  copy_to_dv_container "${EXTENSION_SOURCE_DIR}/conf/xds"
+  echo "* Executing xds setup."
+  exec_script_in_dv_container "xds/xds-setup.sh install_all"
+}
+
+export -f extension_post_install
+
+$DATAVERSE_SOURCE_DIR/dev "$@"
+


### PR DESCRIPTION
Failing workflow was due to obsolete xds version. So the actual fix is about updating the xds version.

This PR adds xds workflow configuration and setup during `./dev install`, in order to be able to test and reproduce such cases in the development environment.

Depends on CeON/dataverse#2685